### PR TITLE
ci(release): publish via npm trusted publisher (OIDC)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,13 +6,6 @@ on:
       - opened
       - synchronize
       - reopened
-    paths:
-      - 'lib/**'
-      - 'tests/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'tsconfig.json'
-      - '.github/workflows/pull_request.yml'
   merge_group:
 
 permissions:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,6 +6,13 @@ on:
       - opened
       - synchronize
       - reopened
+    paths:
+      - 'lib/**'
+      - 'tests/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - '.github/workflows/pull_request.yml'
   merge_group:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,9 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: '24'
           cache: npm
 
-      - run: npm install -g npm@latest
       - run: npm clean-install
       - run: npm audit signatures
       - run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,16 +44,19 @@ jobs:
           node-version: lts/*
           cache: npm
 
+      - run: npm install -g npm@latest
       - run: npm clean-install
       - run: npm audit signatures
       - run: npm run build
 
       - name: Publish
         uses: cycjimmy/semantic-release-action@v4
+        with:
+          extra_plugins: |
+            @semantic-release/npm@12
         env:
           GIT_AUTHOR_NAME: ${{ steps.gpg.outputs.name }}
           GIT_AUTHOR_EMAIL: ${{ steps.gpg.outputs.email }}
           GIT_COMMITTER_NAME: ${{ steps.gpg.outputs.name }}
           GIT_COMMITTER_EMAIL: ${{ steps.gpg.outputs.email }}
           GITHUB_TOKEN: ${{ secrets.OBLAKBOT_PAT }}
-          NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Switch the release workflow to authenticate against npm via the [Trusted Publisher / OIDC](https://docs.npmjs.com/trusted-publishers) flow already configured for this package on npmjs.com, instead of a long-lived static token.

- Remove \`NPM_TOKEN\` env var from the publish step.
- Pin \`@semantic-release/npm@12\` via \`extra_plugins\` (v12.1+ ships OIDC support, independent of the bundled version in \`cycjimmy/semantic-release-action@v4\`).
- Bump \`actions/setup-node\` to Node 24 — its bundled npm 11.x has built-in OIDC trusted-publishing support, so no extra \`npm install -g npm@latest\` step is needed (Node 22 LTS still ships npm 10.x).
- \`permissions: id-token: write\` is already set on the job.

After this lands, the org-level \`NPM_AUTH_TOKEN\` secret can be deleted, and on npmjs.com the package's *Publishing access* should be set to **\"Require 2FA and disallow tokens\"** for maximum security (trusted publishers keep working regardless).

## Test plan

- [ ] Merge to \`master\`, confirm the Release workflow run completes successfully (no \`EINVALIDNPMTOKEN\`).
- [ ] Verify the published version on npmjs.com shows a provenance attestation (sigstore badge).
- [ ] Confirm \`NPM_AUTH_TOKEN\` org secret is no longer referenced anywhere.