### PR TITLE
ci(release): restore npm token; semantic-release pre-flight requires it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,10 @@ jobs:
 
       - name: Publish
         uses: cycjimmy/semantic-release-action@v4
-        with:
-          extra_plugins: |
-            @semantic-release/npm@12
         env:
           GIT_AUTHOR_NAME: ${{ steps.gpg.outputs.name }}
           GIT_AUTHOR_EMAIL: ${{ steps.gpg.outputs.email }}
           GIT_COMMITTER_NAME: ${{ steps.gpg.outputs.name }}
           GIT_COMMITTER_EMAIL: ${{ steps.gpg.outputs.email }}
           GITHUB_TOKEN: ${{ secrets.OBLAKBOT_PAT }}
+          NPM_TOKEN: ${{ secrets.OBLAKBOT_NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Follow-up to #49. The OIDC-only switch was incorrect: \`@semantic-release/npm\` doesn't yet support npm's Trusted Publisher (OIDC-only) flow — its auth-verify step (\`set-npmrc-auth.js\`) hard-requires \`NPM_TOKEN\`, so the post-merge release run failed with \`ENONPMTOKEN\`.

Token auth and OIDC are complementary, not alternatives:

- \`NPM_TOKEN\` — required by semantic-release pre-flight + npm CLI auth.
- \`id-token: write\` + Trusted Publisher on npmjs.com — gives the published artifact a provenance attestation.

This PR re-adds \`NPM_TOKEN\`, pointing at the org-shared \`OBLAKBOT_NPM_TOKEN\` secret that already works in [\`x-wp/wptoolset\`](https://github.com/x-wp/wptoolset/blob/master/.github/workflows/release.yml). The previous \`NPM_AUTH_TOKEN\` reference appears to be unset/expired in the org's secret allowlist for this repo.

The \`extra_plugins: @semantic-release/npm@12\` pin is also dropped — the action's bundled version works (matches the \`xwp/bundler\` setup).

## Test plan

- [ ] Merge to \`master\`, confirm the Release run completes (no \`ENONPMTOKEN\` / \`EINVALIDNPMTOKEN\`).
- [ ] Verify the published version on npmjs.com shows the provenance/sigstore badge — that's the OIDC half still working.